### PR TITLE
Tasks/369 new updates

### DIFF
--- a/src/app/[locale]/components/common/table/table-header-item.tsx
+++ b/src/app/[locale]/components/common/table/table-header-item.tsx
@@ -1,22 +1,53 @@
 'use server';
 
 import { FC } from 'react';
-
+import Tooltip from '@/components/common/tooltip';
 import TableSortItems from '@/components/common/table/table-sort-items';
 import { PagesProps } from '@/types';
 
 interface OwnProps extends PagesProps {
-  name: string;
+  name?: string;
   sortField?: string;
   colspan?: number;
   defaultSelected?: boolean;
   className?: string;
+  tooltip?: string;
+  children?: React.ReactNode;
 }
 
-const TableHeaderItem: FC<OwnProps> = ({ page, sortField, name, className, colspan = 1, defaultSelected = false }) => {
+const TableHeaderItem: FC<OwnProps> = ({
+                                         page,
+                                         sortField,
+                                         name,
+                                         className,
+                                         colspan = 1,
+                                         defaultSelected = false,
+                                         tooltip,
+                                         children
+                                       }) => {
   return (
-    <th className={className} colSpan={colspan}>
-      <TableSortItems page={page} name={name} field={sortField} defaultSelected={defaultSelected} />
+    <th className={`text-center ${className || ''}`} colSpan={colspan}>
+      {children ? (
+        children
+      ) : tooltip ? (
+        <Tooltip tooltip={tooltip}>
+          <span className="cursor-help">
+            <TableSortItems
+              page={page}
+              name={name!}
+              field={sortField}
+              defaultSelected={defaultSelected}
+            />
+          </span>
+        </Tooltip>
+      ) : (
+        <TableSortItems
+          page={page}
+          name={name!}
+          field={sortField}
+          defaultSelected={defaultSelected}
+        />
+      )}
     </th>
   );
 };

--- a/src/app/[locale]/ecosystems/ecosystems-list/ecosystems-list-item.tsx
+++ b/src/app/[locale]/ecosystems/ecosystems-list/ecosystems-list-item.tsx
@@ -15,36 +15,34 @@ const EcosystemListItem: FC<OwnProps> = async ({ item }) => {
   const ecosystemChains = await chainService.getListByEcosystem(item.name);
 
   return (
-    <tr className="group font-handjet hover:bg-bgHover hover:text-highlight">
+    <tr className="font-handjet">
       <td
-        className="group/avatar border-b w-2/12 border-black px-2 py-2 font-sfpro active:border-bgSt">
+        className="group/avatar border-b w-2/12 border-black px-2 py-2 font-sfpro active:border-bgSt hover:bg-bgHover hover:text-highlight">
         <TableAvatar icon={item.logoUrl}
                      name={item.prettyName}
                      href={ecosystemLink} />
       </td>
-      <td className="border-b border-black px-2 py-2 font-handjet text-lg text-center active:border-bgSt">
-        <Link href={ecosystemLink}>$50B</Link>
+      <td className="border-b border-black px-2 py-2 font-handjet text-lg text-center active:border-bgSt hover:bg-bgHover hover:text-highlight">
+        <div className="select-text cursor-default">$50B</div>
       </td>
-      <td className="border-b border-black px-2 py-2 font-handjet text-lg text-center active:border-bgSt">
-        <Link href={ecosystemLink}>$430B</Link>
+      <td className="border-b border-black px-2 py-2 font-handjet text-lg text-center active:border-bgSt hover:bg-bgHover hover:text-highlight">
+        <div className="select-text cursor-default">$430B</div>
       </td>
-      <td className="border-b border-black px-2 py-2 font-handjet text-lg text-center active:border-bgSt">
-        <Link href={ecosystemLink}>
-          120
-        </Link>
+      <td className="border-b border-black px-2 py-2 font-handjet text-lg text-center active:border-bgSt hover:bg-bgHover hover:text-highlight">
+        <div className="select-text cursor-default">120</div>
       </td>
-      <td className="border-b border-black px-2 py-2 font-handjet text-lg text-center active:border-bgSt">
-        <Link href={ecosystemLink}>25000</Link>
+      <td className="border-b border-black px-2 py-2 font-handjet text-lg text-center active:border-bgSt hover:bg-bgHover hover:text-highlight">
+        <div className="select-text cursor-default">25000</div>
       </td>
-      <td className="border-b border-black px-2 py-2 font-handjet text-lg text-center active:border-bgSt">
-        <Link href={ecosystemLink}>$10M</Link>
+      <td className="border-b border-black px-2 py-2 font-handjet text-lg text-center active:border-bgSt hover:bg-bgHover hover:text-highlight">
+        <div className="select-text cursor-default">$10M</div>
       </td>
-      <td className="border-b border-black w-2/12 px-2 py-2 font-handjet text-lg text-center active:border-bgSt">
+      <td className="border-b border-black w-2/12 px-2 py-2 font-handjet text-lg text-center active:border-bgSt hover:bg-bgHover">
         <Link href={ecosystemLink}>
           <div className="flex flex-row flex-wrap whitespace-normal">
-            <div className="rounded-full bg-primary shadow-button px-6 mt-1 mr-2">Tag1</div>
-            <div className="rounded-full bg-primary shadow-button px-6 mt-1 mr-2">Tag2</div>
-            <div className="rounded-full bg-primary shadow-button px-6 mt-1 mr-2">Tag3</div>
+            <div className="rounded-full bg-primary shadow-button px-6 mt-1 mr-2 hover:text-highlight">Tag1</div>
+            <div className="rounded-full bg-primary shadow-button px-6 mt-1 mr-2 hover:text-highlight">Tag2</div>
+            <div className="rounded-full bg-primary shadow-button px-6 mt-1 mr-2 hover:text-highlight">Tag3</div>
           </div>
         </Link>
       </td>

--- a/src/app/[locale]/main-validators/validator-list/validators.tsx
+++ b/src/app/[locale]/main-validators/validator-list/validators.tsx
@@ -20,8 +20,7 @@ const Validators: FC<OwnProps> = async ({ page, sort, perPage, ecosystems = [], 
         perPage={perPage}
         selectedEcosystems={ecosystems}
         isBattery
-        isEcosystems
-        isNetworkStage />
+        isEcosystems />
       <div>
         <table className="relative my-4 w-full table-auto border-collapse">
           <thead>

--- a/src/app/[locale]/networks/[id]/tx/[hash]/expand/expanded-tx-information.tsx
+++ b/src/app/[locale]/networks/[id]/tx/[hash]/expand/expanded-tx-information.tsx
@@ -3,6 +3,7 @@ import { getTranslations } from 'next-intl/server';
 import { FC } from 'react';
 import { txExample } from '@/app/networks/[id]/tx/txExample';
 import CopyButton from '@/components/common/copy-button';
+import Link from 'next/link';
 
 interface OwnProps {
   chain?: Chain;
@@ -17,19 +18,40 @@ const ExpandedTxInformation: FC<OwnProps> = async ({ chain }) => {
         return <div className="font-handjet text-lg hover:text-highlight">{data} {chain?.denom ?? 'ATOM'}</div>;
       case 'delegate address':
         return (
-          <div className="flex flex-row justify-center items-center hover:text-highlight">
-            {data} <CopyButton value={data} size={'md'} />
+          <div className="flex flex-row items-center gap-2 hover:text-highlight">
+            <Link href={`/networks/${chain?.id}/address/${data}/passport`} className="text-highlight hover:underline">
+              {data}
+            </Link>
+            <CopyButton value={data} size={'md'} />
           </div>
         );
       case 'validator address':
-        return (
-          <div>
-            {Array.isArray(data)
-              ? data.map((item, index) =>
-                <div className="hover:text-highlight" key={index}>{item}</div>)
-              : data}
-          </div>
-        );
+        if (Array.isArray(data) && data.length > 1) {
+          const address = data[0];
+          const valName = data[1];
+          return (
+            <div className="flex flex-col gap-1">
+              <div className="flex flex-row items-center gap-2">
+                <Link href={`/networks/${chain?.id}/address/${address}/passport`} className="text-highlight hover:underline">
+                  {address}
+                </Link>
+                <CopyButton value={address} size={'md'} />
+              </div>
+              <Link href={`/validators?search=${encodeURIComponent(valName)}`} className="text-highlight hover:underline">
+                {valName}
+              </Link>
+            </div>
+          );
+        } else {
+          return (
+            <div className="flex flex-row items-center gap-2">
+              <Link href={`/networks/${chain?.id}/address/${data}/passport`} className="text-highlight hover:underline">
+                {data}
+              </Link>
+              <CopyButton value={data} size={'md'} />
+            </div>
+          );
+        }
       case 'auto claim reward':
         return (
           <div>
@@ -49,7 +71,7 @@ const ExpandedTxInformation: FC<OwnProps> = async ({ chain }) => {
       {txExample.expanded.map((item) => (
         <div key={item.title} className="mt-2 flex w-full hover:bg-bgHover">
           <div className="w-3/12 items-center border-b border-r border-bgSt py-4 pl-8 font-sfpro text-lg ">
-            {t(`${item.title as 'delegate address'}`)}
+            {item.title === 'delegate address' ? 'Delegator Address' : t(`${item.title as 'delegate address'}`)}
           </div>
           <div
             className="flex w-9/12 cursor-pointer items-center gap-2 border-b border-bgSt py-4 pl-6 pr-4 font-sfpro text-base">

--- a/src/app/[locale]/networks/[id]/tx/[hash]/layout.tsx
+++ b/src/app/[locale]/networks/[id]/tx/[hash]/layout.tsx
@@ -26,13 +26,25 @@ export default async function TxInformationLayout({ children, params: { locale, 
   const chain = await chainService.getById(chainId);
   const txInformationTabs = getTxInformationTabs(chainId, hash);
 
-  return (<div className="">
-    <PageTitle text={t('title')} />
-    <SubDescription text={t('description')} contentClassName={'m-4'} plusClassName={'mt-2'} />
-    <TxInformation chain={chain} hash={hash} />
-    <div className="w-1/3 mt-5">
-      <TabList tabs={txInformationTabs} page={'TxInformationPage'} />
+  return (
+    <div className="">
+      <PageTitle
+        prefix={
+          <a
+            href={`/networks/${chain?.id}/overview`}
+            className="text-highlight hover:underline"
+          >
+            {chain?.prettyName ?? 'Network'}
+          </a>
+        }
+        text={t('title').replace(/^.*?Blockchain /, 'Blockchain ')}
+      />
+      <SubDescription text={t('description')} contentClassName={'m-4'} plusClassName={'mt-2'} />
+      <TxInformation chain={chain} hash={hash} />
+      {children}
+      <div className="w-1/3 mt-5">
+        <TabList tabs={txInformationTabs} page={'TxInformationPage'} />
+      </div>
     </div>
-    {children}
-  </div>);
+  );
 };

--- a/src/app/[locale]/networks/[id]/tx/[hash]/tx-information.tsx
+++ b/src/app/[locale]/networks/[id]/tx/[hash]/tx-information.tsx
@@ -25,14 +25,33 @@ const TxInformation: FC<OwnProps> = async ({ chain, hash }) => {
         );
       case 'chain id':
         return (
-          <Link href={`/networks/${chain?.id}/overview`}>
+          <div className="flex items-center gap-2">
             {chain?.chainId ?? data}
-          </Link>
+            <CopyButton value={chain?.chainId ?? data} />
+          </div>
         );
       case 'fees':
         return <div className="font-handjet text-lg">{data} {chain?.denom ?? 'ATOM'}</div>;
       case 'block height':
-        return <div className="font-handjet text-lg">{data.toLocaleString('en-En')}</div>;
+        return (
+          <Link href={`/networks/${chain?.id}/block/${data}`} className="font-handjet text-lg text-highlight hover:underline">
+            {data.toLocaleString('en-En')}
+          </Link>
+        );
+      case 'timestamp':
+        return (
+          <div className="flex items-center gap-2">
+            {data}
+            <CopyButton value={data} />
+          </div>
+        );
+      case 'memo':
+        return (
+          <div className="flex items-center gap-2">
+            {data}
+            <CopyButton value={data} />
+          </div>
+        );
       default:
         return data;
     }

--- a/src/app/[locale]/networks/networks-list/networks-list-item.tsx
+++ b/src/app/[locale]/networks/networks-list/networks-list-item.tsx
@@ -32,17 +32,17 @@ const NetworksListItem: FC<OwnProps> = async ({ item }) => {
         </Tooltip>
       </td>
       <td className="border-b border-black px-2 py-2 active:border-bgSt">
-        <Link href={''} className={`${size}`}>
+        <Link href={'https://www.citizenweb3.com/about'} className={`${size}`} target="_blank">
           <div className={`${size} bg-web bg-contain bg-no-repeat hover:bg-web_h`} />
         </Link>
       </td>
       <td className="border-b border-black px-2 py-2 active:border-bgSt">
-        <Link href={''} className={size} target="_blank">
+        <Link href={'https://github.com/citizenweb3/validatorinfo'} className={size} target="_blank">
           <div className={`${size} bg-github bg-contain bg-no-repeat hover:bg-github_h`} />
         </Link>
       </td>
       <td className="border-b border-black px-2 py-2 active:border-bgSt">
-        <Link href={item.twitterUrl ?? ''} className={size} target="_blank">
+        <Link href={'https://x.com/therealvalinfo'} className={size} target="_blank">
           <div className={`${size} bg-x bg-contain bg-no-repeat hover:bg-x_h`} />
         </Link>
       </td>

--- a/src/app/[locale]/networks/networks-list/networks.tsx
+++ b/src/app/[locale]/networks/networks-list/networks.tsx
@@ -2,6 +2,7 @@ import { FC } from 'react';
 
 import NetworksList from '@/app/networks/networks-list/networks-list';
 import ListFilters from '@/components/common/list-filters/list-filters';
+import Tooltip from '@/components/common/tooltip';
 import TableHeaderItem from '@/components/common/table/table-header-item';
 import { SortDirection } from '@/server/types';
 import { PagesProps } from '@/types';
@@ -26,8 +27,14 @@ const Networks: FC<OwnProps> = async ({ ecosystems, page, perPage, sort, current
           <thead>
           <tr className="bg-table_header">
             <TableHeaderItem page={page} name="Network" sortField="name" defaultSelected />
-            <TableHeaderItem page={page} name="Token" />
-            <TableHeaderItem page={page} name="FDV" />
+            <TableHeaderItem page={page} name="Token" sortField="name" defaultSelected />
+            <TableHeaderItem
+              page={page}
+              name="FDV"
+              sortField="name"
+              defaultSelected
+              tooltip="Fully Diluted Valuation"
+            />
             <TableHeaderItem page={page} name="Links" colspan={3} />
           </tr>
           </thead>

--- a/src/app/[locale]/nodes/nodes-list/nodes-list-item.tsx
+++ b/src/app/[locale]/nodes/nodes-list/nodes-list-item.tsx
@@ -23,8 +23,8 @@ const NetworksListItem: FC<OwnProps> = ({ item }) => {
     : '';
 
   return (
-    <tr className="group font-handjet hover:bg-bgHover hover:text-highlight">
-      <td className="flex border-b border-black py-2 font-handjet text-lg active:border-bgSt">
+    <tr className="font-handjet">
+      <td className="flex border-b border-black py-2 font-handjet text-lg active:border-bgSt hover:bg-bgHover hover:text-highlight">
         <Image
           src={item?.jailed ? icons.RedSquareIcon : icons.GreenSquareIcon}
           alt={'node status'}
@@ -40,27 +40,27 @@ const NetworksListItem: FC<OwnProps> = ({ item }) => {
           <CopyButton value={item.operatorAddress} />
         </div>
       </td>
-      <td className="border-b border-black py-2 font-sfpro text-base active:border-bgSt">
+      <td className="border-b border-black py-2 font-sfpro text-base active:border-bgSt hover:bg-bgHover hover:text-highlight">
         <Link href={validatorLink}>
           <div className="text-center">{item.validatorId ? item.moniker : '-'}</div>
         </Link>
       </td>
-      <td className="border-b border-black px-2 py-2 font-sfpro text-base active:border-bgSt">
+      <td className="border-b border-black px-2 py-2 font-sfpro text-base active:border-bgSt hover:bg-bgHover hover:text-highlight">
         <Link href={`/validators?p=1&ecosystems=${item.chain.ecosystem}`}>
           <div className="text-center">{_.capitalize(item.chain.ecosystem)}</div>
         </Link>
       </td>
-      <td className="border-b border-black px-2 py-2 font-sfpro text-base active:border-bgSt">
+      <td className="border-b border-black px-2 py-2 font-sfpro text-base active:border-bgSt hover:bg-bgHover hover:text-highlight">
         <Link href={`/networks/${item.chainId}/overview`}>
           <div className="text-center">{item.chain.prettyName}</div>
         </Link>
       </td>
-      <td className="border-b border-black px-2 py-2 font-handjet text-lg active:border-bgSt">
+      <td className="border-b border-black px-2 py-2 font-handjet text-lg active:border-bgSt hover:bg-bgHover hover:text-highlight">
         <Tooltip tooltip={tokenDelegatorShares.toLocaleString()}>
           <div className="text-center">{formatCash(tokenDelegatorShares)}</div>
         </Tooltip>
       </td>
-      <td className="border-b border-black px-2 py-2 font-sfpro text-base active:border-bgSt">
+      <td className="border-b border-black px-2 py-2 font-sfpro text-base active:border-bgSt hover:bg-bgHover hover:text-highlight">
         {item.uptime ? (
           <Tooltip tooltip={`Per ${item.chain.blocksWindow?.toLocaleString()} blocks`}>
             <div className="text-center" style={{ color: colorStylization.uptime(item.uptime) }}>
@@ -73,7 +73,7 @@ const NetworksListItem: FC<OwnProps> = ({ item }) => {
           </div>
         )}
       </td>
-      <td className="border-b border-black px-2 py-2 font-sfpro text-base active:border-bgSt">
+      <td className="border-b border-black px-2 py-2 font-sfpro text-base active:border-bgSt hover:bg-bgHover hover:text-highlight">
         {item.missedBlocks !== undefined && item.missedBlocks !== null ? (
           <Tooltip tooltip={`Per ${item.chain.blocksWindow?.toLocaleString()} blocks`}>
             <div className="text-center" style={{ color: colorStylization.missedBlocks(item.missedBlocks) }}>

--- a/src/app/[locale]/profile/page.tsx
+++ b/src/app/[locale]/profile/page.tsx
@@ -18,7 +18,7 @@ const ProfilePage: NextPageWithLocale<PageProps> = async ({ params: { locale } }
     <div>
       <div className="flex flex-row justify-between">
         <PageTitle prefix="Welcome" text="User1" />
-        <RoundedButton className="flex self-end text-xl" contentClassName="px-16">{t('Logout')}</RoundedButton>
+        <RoundedButton className="flex self-end text-xl" contentClassName="px-16" href={"/"}>{t('Logout')}</RoundedButton>
       </div>
       <div className="m-4 whitespace-pre-line text-base">{t('description')}</div>
       <div className="my-4 flex items-center justify-end space-x-8">

--- a/src/app/[locale]/validators/[id]/(validator-profile)/governance/validator-votes/validator-votes-items.tsx
+++ b/src/app/[locale]/validators/[id]/(validator-profile)/governance/validator-votes/validator-votes-items.tsx
@@ -6,9 +6,10 @@ import colorStylization from '@/utils/color-stylization';
 
 interface OwnProps {
   item: ValidatorVote;
+  validatorId: number;
 }
 
-const ValidatorVotesItem: FC<OwnProps> = ({ item }) => {
+const ValidatorVotesItem: FC<OwnProps> = ({ item, validatorId }) => {
   const proposalLink = `/networks/${item.chain.id}/proposal/${item.proposalId}`;
   const chainLink = `/networks/${item.chain.id}/overview`;
 
@@ -27,7 +28,7 @@ const ValidatorVotesItem: FC<OwnProps> = ({ item }) => {
         </Link>
       </td>
       <td className="w-1/4 border-b border-black px-2 py-2 text-base hover:text-highlight active:border-bgSt">
-        <Link href={proposalLink} className="flex justify-center">
+        <Link href={`/networks/${item.chain.id}/address/${item.operatorAddress}/passport`} className="flex justify-center">
           <div className="text-center">{item.vote}</div>
         </Link>
       </td>

--- a/src/app/[locale]/validators/[id]/(validator-profile)/governance/validator-votes/validator-votes-list.tsx
+++ b/src/app/[locale]/validators/[id]/(validator-profile)/governance/validator-votes/validator-votes-list.tsx
@@ -38,16 +38,15 @@ const ValidatorVotesList: FC<OwnProps> = async ({ sort, perPage, currentPage = 1
     }
   }
 
+  if (validatorId === undefined) return null;
   return (
     <tbody>
-    {votesList.map((item) => (
-      <ValidatorVotesItem key={item.proposalDbId} item={item} />
-    ))}
-    <tr>
-      <td colSpan={5} className="pt-4">
-        <TablePagination pageLength={pages} isScroll={false} />
-      </td>
-    </tr>
+      {votesList.map((item) => <ValidatorVotesItem key={item.proposalDbId} item={item} validatorId={validatorId} />)}
+      <tr>
+        <td colSpan={5} className="pt-4">
+          <TablePagination pageLength={pages} isScroll={false} />
+        </td>
+      </tr>
     </tbody>
   );
 };

--- a/src/app/[locale]/validators/[id]/(validator-profile)/validator-profile/validator-networks-circle.tsx
+++ b/src/app/[locale]/validators/[id]/(validator-profile)/validator-profile/validator-networks-circle.tsx
@@ -1,10 +1,12 @@
 'use client';
 
 import Image from 'next/image';
+import Link from 'next/link';
 import { FC, useEffect, useState } from 'react';
 
 import ArrowsGoBigButton from '@/components/common/arrows-go-big-button';
 import icons from '@/components/icons';
+import Tooltip from '@/components/common/tooltip';
 
 interface circleValuesTypes {
   circleRadius: number;
@@ -14,7 +16,7 @@ interface circleValuesTypes {
 
 interface OwnProps {
   centerLogo: string;
-  logos: string[];
+  logos: { id: number; logoUrl: string; prettyName: string }[];
 }
 
 const NetworksCircle: FC<OwnProps> = ({ centerLogo, logos }) => {
@@ -74,13 +76,13 @@ const NetworksCircle: FC<OwnProps> = ({ centerLogo, logos }) => {
         />
       </div>
       <div className="relative h-full w-full">
-        {logos.map((logo, index) => {
+        {logos.map((chain, index) => {
           const angle = (index / logos.length) * 2 * Math.PI;
           const x = circleRadius * Math.cos(angle) - logoSize / 2;
           const y = circleRadius * Math.sin(angle) - logoSize / 2;
           return (
             <div
-              key={index}
+              key={chain.id}
               style={{
                 top: `calc(50% + ${y}px)`,
                 left: `calc(50% + ${x}px)`,
@@ -89,11 +91,15 @@ const NetworksCircle: FC<OwnProps> = ({ centerLogo, logos }) => {
               }}
               className="absolute flex items-center justify-center"
             >
-              <Image
-                src={logo}
-                alt={`Logo ${index}`}
-                fill
-                className={`rounded-full h-[${logoSize}] object-contain`} />
+              <Tooltip tooltip={chain.prettyName} direction="top">
+                <Link href={`/networks/${chain.id}/overview`}>
+                  <Image
+                    src={chain.logoUrl}
+                    alt={chain.prettyName}
+                    fill
+                    className={`rounded-full h-[${logoSize}] object-contain`} />
+                </Link>
+              </Tooltip>
             </div>
           );
         })}

--- a/src/app/[locale]/validators/[id]/(validator-profile)/validator-profile/validator-profile.tsx
+++ b/src/app/[locale]/validators/[id]/(validator-profile)/validator-profile/validator-profile.tsx
@@ -22,7 +22,11 @@ const ValidatorProfile: FC<OwnProps> = async ({ id, locale }) => {
   const validatorLogoUrl = validator?.url || icons.AvatarIcon;
 
   const { validatorNodesWithChainData } = await validatorService.getValidatorNodesWithChains(id);
-  const chainsLogos = validatorNodesWithChainData.map((node) => node?.chain.logoUrl || icons.AvatarIcon);
+  const chains = validatorNodesWithChainData.map((node) => ({
+    id: node.chain.id,
+    logoUrl: node.chain.logoUrl || icons.AvatarIcon,
+    prettyName: node.chain.prettyName,
+  }));
 
   if (!validator) {
     return null;
@@ -63,7 +67,7 @@ const ValidatorProfile: FC<OwnProps> = async ({ id, locale }) => {
         </div>
       </div>
       <div className="col-span-3 h-full shadow-button">
-        <NetworksCircle centerLogo={validatorLogoUrl} logos={chainsLogos} />
+        <NetworksCircle centerLogo={validatorLogoUrl} logos={chains} />
       </div>
       <div className="col-span-2 ml-8 2xl:ml-20 xl:ml-18 lg:ml-14 md:ml-10 h-full border-b border-bgSt">
         <h1>

--- a/src/app/services/vote-service.ts
+++ b/src/app/services/vote-service.ts
@@ -12,6 +12,7 @@ export interface ValidatorVote {
   proposalId: string;
   title: string;
   vote: VoteOption;
+  operatorAddress: string;
 }
 
 export interface ProposalValidatorsVotes {
@@ -64,6 +65,7 @@ const getValidatorVotes = async (
           title: true,
         },
       },
+      node: { select: { operatorAddress: true } },
     },
   });
 
@@ -73,6 +75,7 @@ const getValidatorVotes = async (
     proposalId: vote.proposal.proposalId,
     title: vote.proposal.title,
     vote: vote.vote,
+    operatorAddress: vote.node.operatorAddress,
   }));
 
   return { votes, pages };


### PR DESCRIPTION
- Data / help pages. Everything's ready except: clicking tag should in theory filter out the same tags in table. @m1amgn
- Main Page
- dashboard
- tx page
- Val Profile.
other links. Это можно сделать только через отдельный Client Component, верно? Или какой-то другой путь решения есть?
visual: реализовал переход на сеть + при наведении на логотип сети на профиле валидатора появляется тултип с её названием.
"vote type - node passport of network in question" - оформил href через operatorAddress (href={/networks/${item.chain.id}/address/${item.operatorAddress}/passport}), на локале выдает линк .../networks/1/address/undefined/passport

не трогал:
merits are missing text and need separate task to prepare
revenue tab, rumor box needs to work (separate issue)