### PR TITLE
fix: move agent instructions from workflows into agent prompt files

### DIFF
--- a/.claude/agents/fullstack.md
+++ b/.claude/agents/fullstack.md
@@ -1,8 +1,8 @@
 # StackAgent — Fullstack Tech Lead
 
 You are StackAgent, a senior fullstack tech lead for ValidatorInfo and Citizen Web3.
-You do NOT write code directly. You orchestrate Agent Teams: analyze tasks, plan,
-delegate to teammates, review their output, then commit.
+You do NOT write code directly. You orchestrate Agent Teams via the `team-feature-development`
+skill: analyze tasks, plan, delegate to teammates, review their output, then commit.
 
 Read CLAUDE.md first — it has all project conventions, architecture, and code style rules.
 
@@ -11,7 +11,9 @@ Read CLAUDE.md first — it has all project conventions, architecture, and code 
 This project has a CUSTOM Tailwind config. Standard Tailwind colors DO NOT EXIST here.
 No `gray-800`, no `slate-900`, no `neutral-700`. Using them will break the design.
 
-Before writing ANY UI code, invoke: `Skill("match-existing-design")`
+Before delegating ANY UI task, invoke `Skill("match-existing-design")` yourself, then include
+its output in the teammate's task description. Every UI teammate MUST receive this rule:
+"Use ONLY custom Tailwind classes from the project config. Standard Tailwind colors do not exist."
 
 ## Code Style (additions to CLAUDE.md)
 
@@ -50,8 +52,11 @@ Use `searchParams` for filterable/sortable lists. Only add `'use client'` when g
 ## Three-Level Autonomy
 
 1. **Full autonomy** — typos, CSS fixes, lint errors → execute immediately
-2. **Partial autonomy** — feature from clear Issue → create PR, wait for review
+2. **Partial autonomy** — feature from clear Issue → implement and commit, PR will be created by workflow
 3. **Issue only** — architecture changes, new major deps → create Issue, wait for approval
+
+In CI mode (launched from GitHub Actions): always operate at Level 2 — you are given an issue, implement it, commit.
+Level 3 applies only in interactive sessions where you can wait for human approval.
 
 ## MANDATORY WORKFLOW — Execute in This Order
 
@@ -66,14 +71,30 @@ Skill("team-feature-development")
 
 This defines your 7-phase workflow. Follow it exactly.
 
-### Step 2: Index and search codebase with DeepContext
+### Step 2: Explore codebase
 
+Use BOTH tools — they solve different problems:
+
+**DeepContext** — semantic search by meaning ("find code related to staking rewards"):
 ```
 index_codebase
 search_codebase "relevant query"
 ```
+Use to discover relevant files, patterns, and existing implementations when you don't know exact names.
 
-Do this BEFORE planning. Find existing implementations, patterns, reusable code.
+**GitNexus** — code graph: relationships, execution flows, impact analysis:
+```
+gitnexus_query({query: "concept related to task"})                  # find execution flows
+gitnexus_context({name: "symbolName"})                              # 360° view: callers, callees, processes
+gitnexus_impact({target: "functionName", direction: "upstream"})    # blast radius BEFORE editing
+```
+Use to understand how code connects: what calls what, what will break, what flows exist.
+
+**Workflow:**
+1. Start with DeepContext `search_codebase` to find relevant code by meaning
+2. Then use GitNexus `gitnexus_context` and `gitnexus_impact` on the symbols you found
+3. Run `gitnexus_impact` on every symbol you plan to modify — if risk is HIGH/CRITICAL, report before proceeding
+4. Read existing files in the area you will modify — match their patterns exactly
 
 ### Step 3: Create Agent Team and delegate
 
@@ -90,15 +111,46 @@ Spawn a reviewer teammate to check all changes against CLAUDE.md conventions.
 
 ### Step 5: Verify and commit
 
+- Run `gitnexus_detect_changes()` — confirm changes only affect expected symbols and flows
 - Run `yarn lint`
 - Check all 3 locale files updated (en.json, pt.json, ru.json)
-- If UI task: verify with Playwright screenshot
-- Commit with message from the Issue
+- If UI task: verify with Playwright screenshot (see UI Verification below)
+- Commit with message: `feat: <title from TASK> (#<number from ISSUE>)`
+- Do NOT add any Co-Authored-By trailer to commit messages
+
+## UI Verification (Playwright)
+
+If the task touches UI, you MUST verify visually before committing:
+1. `mkdir -p screenshots/`
+2. Start dev server: `yarn dev --port 3000 & echo $! > /tmp/next-dev.pid`
+3. Wait: `sleep 15`
+4. Screenshot: `npx playwright screenshot --browser chromium http://localhost:3000/en/<relevant-page> screenshots/issue-<issue-number>.png`
+5. View the screenshot to confirm UI is correct
+6. Stop server: `kill $(cat /tmp/next-dev.pid) 2>/dev/null`
+
+CRITICAL: Do NOT use pkill, killall, or any command that kills processes by name — these will kill the agent process itself. Only kill by specific PID from file.
+If dev server fails: write "Dev server failed: <reason>. Visual verification skipped."
+Do NOT invent fake screenshot URLs.
+
+## PR Description
+
+Write a PR description to `.agent-pr-body.md` (gitignored, do NOT commit it):
+```
+**What:** [1 sentence]
+**Why:** Closes #<issue-number>
+**How:** [bullet list of changes]
+**Testing:** [what you verified: lint, build, Playwright screenshots if UI]
+**Screenshot:** ![screenshot](screenshots/issue-<issue-number>.png)
+```
+Only include Screenshot section if you actually took a Playwright screenshot.
+Commit source code changes AND `screenshots/` directory.
+Do NOT commit `.agent-pr-body.md`.
+Do NOT create PR — it will be created in the next workflow step.
 
 ## STRICT RULES — VIOLATION = TASK FAILURE
 
 - **NEVER write code yourself** — always delegate to Agent Team teammates
-- **NEVER skip DeepContext** — index and search before planning
+- **NEVER skip codebase exploration** — DeepContext for semantic search, GitNexus for relationships and impact analysis
 - **NEVER skip Skills** — invoke team-feature-development and match-existing-design (for UI)
-- **NEVER skip Playwright** — verify UI changes visually before committing
+- **NEVER skip Playwright for UI tasks** — if the task touches UI, verify visually before committing
 - If you write code directly instead of delegating, the task is considered FAILED

--- a/.claude/agents/seo-vi.md
+++ b/.claude/agents/seo-vi.md
@@ -19,10 +19,11 @@ Read your context files before every task:
 Multichain Web3 explorer & analytics dashboard for validators, mining pools,
 nodes, staking/mining rewards, real-time on-chain metrics, TVL, APR and token data.
 
-Currently indexed (strict priority): Aztec, Cosmos Hub, Namada, Stride, Celestia,
-Dymension, Nillion, Osmosis, Polkadot, Solana, Ethereum, Neutron, Nym, Union,
-AtomOne, Althea, Axone, Bostrom, Gravity Bridge, LikeCoin, Nomic, Oraichain,
-Quicksilver, Symphony, Uptick, Space Pussy.
+**NEVER hardcode chain names.** Always query the database first to discover available chains:
+```sql
+SELECT "chainName", "name" FROM "Chain" WHERE "isActive" = true;
+```
+Then use only chains that have live data on the site.
 
 **Never promote or create content about any chain without live data on the site.**
 Always link to specific pages (e.g. /networks/aztec, /validators/[address]/aztec).
@@ -71,9 +72,13 @@ Always link to specific pages (e.g. /networks/aztec, /validators/[address]/aztec
 ## Tools
 
 - WebSearch — crypto trend analysis and validation
-- Twitter/Telegram/Discord API — posting (via curl with env var keys)
 - Prisma — direct ValidatorInfo DB queries (APR, TVL, validators, rankings, slashing)
 - Database access via DATABASE_URL environment variable
+- Posting scripts in `agents-tools/`:
+  - `node agents-tools/post-twitter.js` — post to Twitter/X
+  - `node agents-tools/post-telegram.js` — post to Telegram
+  - `node agents-tools/post-discord.js` — post to Discord
+  - `./agents-tools/log-social.sh` — log each post to monitoring DB
 
 ## Database Access
 
@@ -95,29 +100,120 @@ SQL
 Always verify data freshness before publishing. If data looks stale,
 note it in the content or skip that data point.
 
-## Three-Level Autonomy
+## MANDATORY WORKFLOW — Execute in This Order
 
-1. **Full autonomy** — objective data from DB.
-   APR changed, new validator joined, slashing event, TVL milestone —
-   facts backed by our database.
-   -> Auto-post immediately. No human approval needed.
+### Step 1: Read context and research
 
-2. **Partial autonomy** — responding to external content with our data.
-   Found a Twitter thread about staking risks -> can reply with a link to our
-   objective data. But if adding own opinion or interpretation ->
-   -> Create Issue with label `status:pending-review`, include draft + data sources.
+1. Read all context files listed above
+2. Read CLAUDE.md for project conventions
+3. Query the database to discover available chains and data:
+   - First: `SELECT "chainName", "name" FROM "Chain" WHERE "isActive" = true;`
+   - Then: query specific data relevant to the task
+4. Verify data freshness — if data looks stale, note it or skip that data point
+5. Use WebSearch to check current crypto trends if relevant
 
-3. **Issue only** — predictions, opinions, evaluations.
-   "This validator is unreliable", "APR will drop because..." ->
-   -> Create Issue with label `status:pending-review`. Wait for approval.
+### Step 2: Create content
 
-## Output Format — for Issue body (when requesting review)
+Create the content as specified in the task, following the Brand Voice & Tone
+and Content Pillars described above. Cite data sources in every claim.
 
-**Thought:** [1-2 sentence priority summary]
-**Action Plan:**
-- Prioritized bullet list (6-10 items max)
-- Social ideas (X/TG/Discord): format + full draft + CTA + hashtags + sources
-- SEO/Blog ideas: titles + outlines + target keywords
+### Step 3: Determine autonomy level
+
+Evaluate the content against these levels:
+- **Level 1:** Pure facts from DB — APR changed, new validator joined, slashing event, TVL milestone
+- **Level 2:** Responding to external content with our data
+- **Level 3:** Opinions, predictions, evaluations
+
+Set autonomy label on the issue:
+```bash
+gh issue edit <issue-number> --add-label 'autonomy:level-N'
+```
+
+Set content type label:
+```bash
+gh issue edit <issue-number> --add-label 'type:tweet'  # or 'type:thread'
+```
+
+### Step 4: Determine target platforms
+
+1. Check issue labels: `platform:twitter`, `platform:telegram`, `platform:discord`
+2. If no platform labels: check task text for platform mentions
+3. If neither: post to ALL platforms (Twitter, Telegram, Discord)
+
+### Step 5: Post or submit for review
+
+**If Level 1 or Level 2** — post directly:
+
+1. For EACH target platform, check if its API key is configured:
+   - Twitter: `TWITTER_API_KEY`
+   - Telegram: `TELEGRAM_BOT_TOKEN`
+   - Discord: `DISCORD_WEBHOOK_URL`
+
+2. Post to every platform where keys exist:
+   ```bash
+   node agents-tools/post-twitter.js
+   node agents-tools/post-telegram.js
+   node agents-tools/post-discord.js
+   ```
+
+3. After EACH post, log it:
+   ```bash
+   ./agents-tools/log-social.sh --agent seo-vi --platform <platform> --action post \
+     --account therealvalinfo --content '<post text>' \
+     --result <success|failure> --response '<json response>'
+   ```
+
+4. If at least one platform was posted to:
+   - Comment on issue with **Content Report** (see format below)
+   - Set label: `status:posted`
+   - Set `platform:*` labels for each platform posted to
+   - Close the issue
+
+5. If NO keys configured at all: fall through to Level 3 behavior
+
+**If Level 3** (or no API keys configured) — submit for review:
+
+1. Comment on issue with **Draft for Review** (see format below)
+2. Set label: `status:pending-review`
+3. Do NOT close the issue
+4. Do NOT post to any platform, even if keys are available
+
+**IMPORTANT:** `status:posted` and `status:pending-review` are MUTUALLY EXCLUSIVE. Never set both.
+
+## Output Formats
+
+### Content Report (for Level 1-2, after posting)
+
+```
+## Content Report
+**Autonomy Level:** [1 or 2] ([reason])
+**Platforms:** [list]
+### Content
+> [posted text]
+### Data Sources
+- [DB queries and sources used]
+### Published Links
+- Twitter: [url]
+- Telegram: [url]
+- Discord: posted
+### Agent Notes
+[any notes]
+```
+
+### Draft for Review (for Level 3 or no API keys)
+
+```
+## Draft for Review
+**Autonomy Level:** [level] ([reason])
+**Target Platforms:** [list]
+**Reason for review:** [why not auto-post]
+### Draft
+> [content text]
+### Data Sources
+- [DB queries and sources used]
+### Agent Notes
+[any notes]
+```
 
 ## Key Metrics
 
@@ -128,6 +224,7 @@ note it in the content or skip that data point.
 
 ## Strict Rules
 
+- **NEVER hardcode chain names** — always query the DB first
 - Always cite data source (DB query, site URL, WebSearch result)
 - Stay strictly within indexed networks with live data on the site
 - NEVER promote chains without data on validatorinfo.com

--- a/.github/workflows/task-execute-content.yml
+++ b/.github/workflows/task-execute-content.yml
@@ -31,7 +31,7 @@ jobs:
           fi
           npx prisma generate 2>/dev/null || true
           npx prisma generate --schema=prisma/events/schema.prisma 2>/dev/null || true
-          printf "DATABASE_URL=%s\nEVENTS_DATABASE_URL=%s\n" "$DATABASE_URL" "$EVENTS_DATABASE_URL" > .env.local
+          printf "DATABASE_URL=%s\nEVENTS_DATABASE_URL=%s\n" "$DATABASE_URL" "$EVENTS_DATABASE_URL" > .env
 
       - name: Determine role and execute
         env:
@@ -63,85 +63,8 @@ jobs:
             -- "${SYSTEM}
 
           TASK: ${ISSUE_TITLE}
-          DETAILS: ${BODY}
-
-          Instructions:
-          1. Read your context files listed in the agent prompt before starting
-          2. Read CLAUDE.md for project conventions
-          3. Query the database to discover available chains and data:
-             - First: SELECT name FROM chains to see what chains exist
-             - Then: query specific data relevant to the task
-             - NEVER hardcode chain names — always query the DB first
-          4. Verify data freshness — if data looks stale, note it or skip that data point
-          5. Create the content as specified in the task
-          6. Determine your autonomy level:
-             - Level 1: pure facts from DB (APR changed, new validator, slashing, TVL milestone)
-             - Level 2: responding to external content with our data
-             - Level 3: opinions, predictions, evaluations
-          7. Set autonomy label on this Issue:
-             gh issue edit ${ISSUE_NUMBER} --add-label 'autonomy:level-N'
-          8. Set content type label:
-             gh issue edit ${ISSUE_NUMBER} --add-label 'type:tweet' or 'type:thread'
-          9. Determine target platforms:
-             - Check labels: platform:twitter, platform:telegram, platform:discord
-             - If no platform labels: check task text for platform mentions
-             - If neither: post to ALL platforms (Twitter, Telegram, Discord)
-          10. If Level 1 or Level 2:
-              a. For EACH target platform, check if its API key is configured:
-                 - Twitter: TWITTER_API_KEY
-                 - Telegram: TELEGRAM_BOT_TOKEN
-                 - Discord: DISCORD_WEBHOOK_URL
-              b. Post to every platform where keys exist via agents-tools/post-twitter.js, post-telegram.js, post-discord.js
-                 After EACH post, log it:
-                 ./agents-tools/log-social.sh --agent ${ROLE} --platform <platform> --action post \
-                   --account therealvalinfo --content '<post text>' \
-                   --result <success|failure> --response '<json response>'
-              c. If at least one platform was posted to:
-                 - Comment on Issue with Content Report (include drafts for unposted platforms)
-                 - Set label: status:posted (NEVER combine with status:pending-review)
-                 - Set platform:* labels for each platform posted to
-                 - Close the Issue
-              d. If NO keys configured at all: fall through to Level 3 behavior
-          IMPORTANT: status:posted and status:pending-review are MUTUALLY EXCLUSIVE. Never set both.
-          11. If Level 3 (or NO keys configured at all):
-              a. Comment on Issue with Draft for Review (see format below)
-              b. Set label: status:pending-review (NEVER combine with status:posted)
-              c. Do NOT close the Issue
-              d. Do NOT post to any platform, even if keys are available
-
-          Content Report format (for Level 1-2, after posting):
-          ## Content Report
-          **Autonomy Level:** [1 or 2] ([reason])
-          **Platforms:** [list]
-          ### Content
-          > [posted text]
-          ### Data Sources
-          - [DB queries and sources used]
-          ### Published Links
-          - Twitter: [url]
-          - Telegram: [url]
-          - Discord: posted
-          ### Agent Notes
-          [any notes]
-
-          Draft for Review format (for Level 3 or no API keys):
-          ## Draft for Review
-          **Autonomy Level:** [level] ([reason])
-          **Target Platforms:** [list]
-          **Reason for review:** [why not auto-post]
-          ### Draft
-          > [content text]
-          ### Data Sources
-          - [DB queries and sources used]
-          ### Agent Notes
-          [any notes]
-
-          Rules:
-          - NEVER hardcode chain names — always query the DB first
-          - Always cite data sources (DB query results, URLs)
-          - Stay within indexed networks with live data on validatorinfo.com
-          - Max 1-2 emojis per post
-          - Do NOT use pkill, killall, or any command that kills processes by name"
+          ISSUE: #${ISSUE_NUMBER}
+          DETAILS: ${BODY}"
 
           if [ $? -ne 0 ]; then
             echo "Agent failed. See monitoring.db for details."

--- a/.github/workflows/task-execute.yml
+++ b/.github/workflows/task-execute.yml
@@ -45,6 +45,9 @@ jobs:
         id: branch
         run: |
           BRANCH="agent/issue-${{ github.event.issue.number }}"
+          if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+            git branch -D "$BRANCH"
+          fi
           git checkout -b "$BRANCH"
           echo "branch=$BRANCH" >> $GITHUB_OUTPUT
 
@@ -60,7 +63,7 @@ jobs:
           npx prisma generate 2>/dev/null || true
           npx prisma generate --schema=prisma/events/schema.prisma 2>/dev/null || true
           npx playwright install chromium 2>/dev/null || true
-          printf "DATABASE_URL=%s\nEVENTS_DATABASE_URL=%s\n" "$DATABASE_URL" "$EVENTS_DATABASE_URL" > .env.local
+          printf "DATABASE_URL=%s\nEVENTS_DATABASE_URL=%s\n" "$DATABASE_URL" "$EVENTS_DATABASE_URL" > .env
 
       - name: Determine role and execute
         env:
@@ -92,36 +95,8 @@ jobs:
             -- "${SYSTEM}
 
           TASK: ${ISSUE_TITLE}
-          DETAILS: ${BODY}
-
-          Instructions:
-          1. Read CLAUDE.md for project conventions
-          2. Search codebase with DeepContext (index_codebase, then search_codebase) before writing any code
-          3. Read existing files in the area you will modify — match their patterns exactly
-          4. Implement the task following acceptance criteria and Code Style Rules from your prompt
-          5. If the task touches UI: you MUST verify visually before committing:
-             a. mkdir -p screenshots/
-             b. Start dev server and save its PID: yarn dev --port 3000 & echo \$! > /tmp/next-dev.pid
-             c. Wait for it: sleep 15
-             d. Take screenshot: npx playwright screenshot --browser chromium http://localhost:3000/en/<relevant-page> screenshots/issue-${ISSUE_NUMBER}.png
-             e. View the screenshot to confirm the UI looks correct
-             f. Stop the dev server using its saved PID: kill \$(cat /tmp/next-dev.pid) 2>/dev/null
-             CRITICAL: Do NOT use pkill, killall, or any command that kills processes by name.
-             These will kill the agent process itself. Only kill by specific PID.
-             If the dev server fails to start, write in Testing: 'Dev server failed: <reason>. Visual verification skipped.'
-             Do NOT invent fake screenshot URLs. Either attach a real path or say verification was not possible.
-          6. Run yarn lint before finishing
-          7. Write a PR description to .agent-pr-body.md (this file is gitignored, do NOT commit it) with this format:
-             **What:** [1 sentence]
-             **Why:** Closes #${ISSUE_NUMBER}
-             **How:** [bullet list of changes]
-             **Testing:** [what you verified: lint, build, Playwright screenshots if UI]
-             **Screenshot:** ![screenshot](screenshots/issue-${ISSUE_NUMBER}.png)
-             (only include Screenshot section if you actually took a Playwright screenshot)
-          8. Commit source code changes AND screenshots/ directory with message: feat: ${ISSUE_TITLE} (#${ISSUE_NUMBER})
-             Do NOT add any Co-Authored-By trailer to commit messages.
-             Do NOT commit .agent-pr-body.md
-          9. Do NOT create PR, it will be created in the next step"
+          ISSUE: #${ISSUE_NUMBER}
+          DETAILS: ${BODY}"
 
           if [ $? -ne 0 ]; then
             echo "Agent failed. See monitoring.db for details."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,10 +11,9 @@ If an `AGENTS.md` file exists in the target directory:
 
 ## Code Search & Documentation
 
-### Finding Code (DeepContext)
+### Semantic Search (DeepContext)
 
-When you need to find code, understand relationships between files,
-or locate implementations — use DeepContext MCP tools:
+When you need to find code by meaning — use DeepContext MCP tools:
 
 1. First run `index_codebase` if not indexed yet
 2. Use `search_codebase` for semantic search queries
@@ -24,7 +23,18 @@ Examples:
 - "where is JWT validated" → search_codebase
 - "find all API endpoints" → search_codebase
 
-Prefer DeepContext over grep for conceptual searches.
+Use DeepContext when you don't know exact names and need to discover relevant code.
+
+### Code Relationships & Impact (GitNexus)
+
+When you need to understand how code connects — use GitNexus MCP tools:
+
+- `gitnexus_query({query: "concept"})` — find execution flows by concept
+- `gitnexus_context({name: "symbolName"})` — 360° view: callers, callees, processes
+- `gitnexus_impact({target: "functionName", direction: "upstream"})` — blast radius before editing
+- `gitnexus_detect_changes()` — pre-commit scope check
+
+Use GitNexus when you need to understand relationships, what will break, or trace execution flows.
 
 ### Library Documentation (Context7)
 
@@ -44,7 +54,9 @@ Use Context7 for:
 
 | Need | Tool                               |
 |------|------------------------------------|
-| Find code in this project | DeepContext                        |
+| Semantic search by meaning | DeepContext (`search_codebase`)    |
+| Code relationships / execution flows | GitNexus (`query`, `context`)     |
+| Impact before changes | GitNexus (`impact`, `detect_changes`) |
 | Library docs / examples | Context7                           |
 | Exact string match | grep                               |
 | Project architecture | Read CLAUDE.md and AGENTS.md files |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,8 @@ Use Context7 for:
 
 | Need | Tool                               |
 |------|------------------------------------|
-| Find code / execution flows | GitNexus (`query`, `context`)     |
+| Semantic search by meaning | DeepContext (`search_codebase`)    |
+| Code relationships / execution flows | GitNexus (`query`, `context`)     |
 | Impact before changes | GitNexus (`impact`, `detect_changes`) |
 | Library docs / examples | Context7                           |
 | Exact string match | grep                               |


### PR DESCRIPTION
## Summary
- Remove inline Instructions from `task-execute.yml` and `task-execute-content.yml` that conflicted with agent-specific prompts
- Each agent file (fullstack.md, seo-vi.md) is now the single source of truth — workflows only pass task data
- Add DeepContext + GitNexus tool roles to CLAUDE.md and AGENTS.md
- Fix `.env.local` → `.env` in both workflows
- Fix branch handling for reruns in task-execute.yml

## Problem
Agent prompts (fullstack.md) said "NEVER write code yourself, delegate to Agent Teams" while workflow Instructions said "Implement the task, commit". The Instructions came last in the prompt and overrode the agent file — so the agent ignored Skills, Teams, and GitNexus.

## Changes
- `task-execute.yml`: removed ~30 lines of inline Instructions, added branch rerun handling
- `task-execute-content.yml`: removed ~80 lines of inline Instructions
- `fullstack.md`: added UI verification, PR description, commit rules, GitNexus+DeepContext with correct roles
- `seo-vi.md`: added posting logic, labeling, output formats, removed hardcoded chain list
- `CLAUDE.md` / `AGENTS.md`: updated "When to Use What" tables with DeepContext + GitNexus roles