### PR TITLE
feat: Data tables color bug

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,15 @@
+# These are supported funding model platforms
+
+github: citizenweb3
+patreon: # Replace with a single Patreon username
+open_collective: # Replace with a single Open Collective username
+ko_fi: # Replace with a single Ko-fi username
+tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+liberapay: # Replace with a single Liberapay username
+issuehunt: # Replace with a single IssueHunt username
+lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
+polar: # Replace with a single Polar username
+buy_me_a_coffee: # Replace with a single Buy Me a Coffee username
+thanks_dev: # Replace with a single thanks.dev username
+custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # [Validator Info](https://validatorinfo.com/)
+[![Sponsor](https://img.shields.io/badge/Sponsor-%E2%9D%A4-red)](https://github.com/sponsors/citizenweb3)
+
 > Web3 Blockchain Explorer. Validator, Mining Pool, Token and Network Real-time Metrics 
 
 > Interactive Onchain Dashboard

--- a/src/utils/color-stylization.ts
+++ b/src/utils/color-stylization.ts
@@ -8,11 +8,11 @@ const yellowTextLayout: string = '#E5C46B';
 const delegation = (selfDelegation: number | null) => {
   if (selfDelegation !== null) {
     if (Number(selfDelegation) < 1000) {
-      return greenTextLayout;
+      return redTextLayout;
     } else if (Number(selfDelegation) < 2000 && Number(selfDelegation) >= 1000) {
       return yellowTextLayout;
     } else {
-      return redTextLayout;
+      return greenTextLayout;
     }
   }
 


### PR DESCRIPTION
**What:** Fix inverted self-delegation color styling in all data tables.
**Why:** Closes #447 — validators with high self-delegation (e.g. 100k) were shown in red instead of green.
**How:**
- Swapped `greenTextLayout` and `redTextLayout` in the `delegation()` function in `src/utils/color-stylization.ts`
- Now: < 1000 = red (low/risky), 1000–2000 = yellow, >= 2000 = green (healthy)
- This single function is the color source for both `network-validators-item.tsx` and `validator-networks-item.tsx` tables
**Testing:** ESLint and TypeScript type-check pass on changed file.