### PR TITLE
feat: Update infrastructure validators page

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,15 @@
+# These are supported funding model platforms
+
+github: citizenweb3
+patreon: # Replace with a single Patreon username
+open_collective: # Replace with a single Open Collective username
+ko_fi: # Replace with a single Ko-fi username
+tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+liberapay: # Replace with a single Liberapay username
+issuehunt: # Replace with a single IssueHunt username
+lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
+polar: # Replace with a single Polar username
+buy_me_a_coffee: # Replace with a single Buy Me a Coffee username
+thanks_dev: # Replace with a single thanks.dev username
+custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # [Validator Info](https://validatorinfo.com/)
+[![Sponsor](https://img.shields.io/badge/Sponsor-%E2%9D%A4-red)](https://github.com/sponsors/citizenweb3)
+
 > Web3 Blockchain Explorer. Validator, Mining Pool, Token and Network Real-time Metrics 
 
 > Interactive Onchain Dashboard

--- a/messages/en.json
+++ b/messages/en.json
@@ -971,6 +971,8 @@
     "websocket nodes": "WebSocket Nodes",
     "indexer nodes": "Indexer Nodes",
     "lcd nodes": "LCD Nodes",
+    "masp indexer nodes": "MASP Indexer Nodes",
+    "interface nodes": "Staking Interface Nodes",
     "relayer nodes": "Relayer Nodes",
     "archive nodes": "Archive Nodes",
     "others nodes": "Other Nodes",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -971,6 +971,8 @@
     "websocket nodes": "Nós WebSocket",
     "indexer nodes": "Nós Indexadores",
     "lcd nodes": "Nós LCD",
+    "masp indexer nodes": "Nós de Indexador MASP",
+    "interface nodes": "Nós de Interface de Staking",
     "relayer nodes": "Nos de retransmissão",
     "archive nodes": "Nós de Arquivo",
     "others nodes": "Outros Nós",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -971,6 +971,8 @@
     "websocket nodes": "WebSocket Ноды",
     "indexer nodes": "Ноды Индексаторы",
     "lcd nodes": "LCD Ноды",
+    "masp indexer nodes": "Узлы индексатора MASP",
+    "interface nodes": "Узлы интерфейса стейкинга",
     "relayer nodes": "Ноды Ретрансляторы",
     "archive nodes": "Архивные Ноды",
     "others nodes": "Другие Ноды",

--- a/server/jobs/check-nodes-health.ts
+++ b/server/jobs/check-nodes-health.ts
@@ -1,3 +1,5 @@
+import net from 'net';
+
 import db from '@/db';
 import logger from '@/logger';
 
@@ -146,6 +148,129 @@ async function checkGenericHealth(url: string): Promise<HealthCheckResult> {
   }
 }
 
+async function checkGrpcHealth(url: string): Promise<HealthCheckResult> {
+  const startTime = Date.now();
+
+  return new Promise((resolve) => {
+    try {
+      let host = url.replace(/^https?:\/\//, '').replace(/^grpc:\/\//, '');
+      let port = 9090;
+
+      const portMatch = host.match(/:(\d+)$/);
+      if (portMatch) {
+        port = parseInt(portMatch[1], 10);
+        host = host.replace(/:\d+$/, '');
+      }
+
+      host = host.replace(/\/.*$/, '');
+
+      const socket = new net.Socket();
+      const timeout = 5000;
+
+      socket.setTimeout(timeout);
+
+      socket.on('connect', () => {
+        const responseTime = Date.now() - startTime;
+        socket.destroy();
+        resolve({ success: true, responseTime });
+      });
+
+      socket.on('timeout', () => {
+        socket.destroy();
+        resolve({ success: false, responseTime: null, error: 'Connection timeout' });
+      });
+
+      socket.on('error', (err: Error) => {
+        socket.destroy();
+        resolve({ success: false, responseTime: null, error: err.message || 'Connection failed' });
+      });
+
+      socket.connect(port, host);
+    } catch (error: any) {
+      resolve({ success: false, responseTime: null, error: error.message || 'Unknown error' });
+    }
+  });
+}
+
+async function checkWsHealth(url: string): Promise<HealthCheckResult> {
+  const startTime = Date.now();
+
+  return new Promise((resolve) => {
+    try {
+      let wsUrl = url;
+      if (wsUrl.startsWith('http://')) {
+        wsUrl = wsUrl.replace('http://', 'ws://');
+      } else if (wsUrl.startsWith('https://')) {
+        wsUrl = wsUrl.replace('https://', 'wss://');
+      } else if (!wsUrl.startsWith('ws://') && !wsUrl.startsWith('wss://')) {
+        wsUrl = `wss://${wsUrl}`;
+      }
+
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), 5000);
+
+      const httpUrl = wsUrl.replace('wss://', 'https://').replace('ws://', 'http://');
+
+      fetch(httpUrl, {
+        headers: {
+          'Upgrade': 'websocket',
+          'Connection': 'Upgrade',
+          'Sec-WebSocket-Key': Buffer.from(Math.random().toString()).toString('base64'),
+          'Sec-WebSocket-Version': '13',
+        },
+        signal: controller.signal,
+      })
+        .then((response) => {
+          clearTimeout(timeoutId);
+          const responseTime = Date.now() - startTime;
+
+          if (response.status === 101 || response.status === 200 || response.status === 426) {
+            resolve({ success: true, responseTime });
+          } else {
+            resolve({ success: false, responseTime: null, error: `HTTP ${response.status}` });
+          }
+        })
+        .catch((error: any) => {
+          clearTimeout(timeoutId);
+          const responseTime = Date.now() - startTime;
+
+          if (error.message?.includes('upgrade') || error.code === 'ERR_INVALID_PROTOCOL') {
+            resolve({ success: true, responseTime });
+          }
+
+          resolve({ success: false, responseTime: null, error: error.message || 'WebSocket connection failed' });
+        });
+    } catch (error: any) {
+      resolve({ success: false, responseTime: null, error: error.message || 'Unknown error' });
+    }
+  });
+}
+
+async function checkNamadaIndexerHealth(url: string): Promise<HealthCheckResult> {
+  const startTime = Date.now();
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 5000);
+
+  try {
+    const endpoint = `${url}/api/v1/chain/parameters`;
+    const response = await fetch(endpoint, {
+      signal: controller.signal,
+    });
+
+    clearTimeout(timeoutId);
+    const responseTime = Date.now() - startTime;
+
+    if (response.ok) {
+      return { success: true, responseTime };
+    }
+
+    return { success: false, responseTime: null, error: `HTTP ${response.status}` };
+  } catch (error: any) {
+    clearTimeout(timeoutId);
+    return { success: false, responseTime: null, error: error.message || 'Unknown error' };
+  }
+}
+
 interface NodeHealthUpdate {
   nodeId: number;
   status: string;
@@ -169,11 +294,6 @@ async function checkNodeHealth(
 
   logInfo(`Checking ${chainName}/${type}: ${normalizedUrl}`);
 
-  if (type === 'ws' || type === 'grpc') {
-    logError(`Skipping ${type} node (not suitable for HTTP health checks)`);
-    return null;
-  }
-
   switch (type) {
     case 'rpc':
       result = await checkRpcHealth(normalizedUrl);
@@ -182,7 +302,17 @@ async function checkNodeHealth(
     case 'lcd':
       result = await checkRestHealth(normalizedUrl);
       break;
+    case 'grpc':
+      result = await checkGrpcHealth(normalizedUrl);
+      break;
+    case 'ws':
+      result = await checkWsHealth(normalizedUrl);
+      break;
+    case 'masp-indexer':
+      result = await checkNamadaIndexerHealth(normalizedUrl);
+      break;
     case 'indexer':
+    case 'interface':
     case 'entry':
     case 'exit':
     default:
@@ -261,11 +391,6 @@ async function checkNodesHealth(): Promise<void> {
     for (const node of chainNodes) {
       if (!node.url) {
         logError(`Skipping node ${node.id} - no URL`);
-        skippedCount++;
-        continue;
-      }
-
-      if (node.type === 'ws' || node.type === 'grpc') {
         skippedCount++;
         continue;
       }

--- a/server/jobs/check-nodes-health.ts
+++ b/server/jobs/check-nodes-health.ts
@@ -235,7 +235,7 @@ async function checkWsHealth(url: string): Promise<HealthCheckResult> {
           const responseTime = Date.now() - startTime;
 
           if (error.message?.includes('upgrade') || error.code === 'ERR_INVALID_PROTOCOL') {
-            resolve({ success: true, responseTime });
+            return resolve({ success: true, responseTime });
           }
 
           resolve({ success: false, responseTime: null, error: error.message || 'WebSocket connection failed' });

--- a/server/tools/chains/chain-indexer.ts
+++ b/server/tools/chains/chain-indexer.ts
@@ -6,7 +6,7 @@ import { Prisma } from '.prisma/client';
 import ProposalCreateInput = Prisma.ProposalCreateInput;
 import { Chain } from '@prisma/client';
 
-export type ChainNodeType = 'indexer' | 'rest' | 'rpc' | 'grpc' | 'ws' | 'exit' | 'entry';
+export type ChainNodeType = 'indexer' | 'rest' | 'rpc' | 'grpc' | 'ws' | 'exit' | 'entry' | 'masp-indexer' | 'interface';
 
 export interface StakingParams {
   unbondingTime: number | null;

--- a/server/tools/chains/namada/get-infrastructure.ts
+++ b/server/tools/chains/namada/get-infrastructure.ts
@@ -17,6 +17,16 @@ interface NamadaMASPEntry {
   'GitHub Account'?: string;
 }
 
+interface NamadaInterfaceEntry {
+  'Interface Name': string;
+  'Interface URL': string;
+  'Available': string;
+  'Notes': string;
+  'Team or Contributor Name': string;
+  'Discord UserName'?: string;
+  'GitHub Account'?: string;
+}
+
 interface NamadaNode {
   type: ChainNodeType;
   url: string;
@@ -28,11 +38,19 @@ const NAMADA_REGISTRIES = {
     rpc: 'https://raw.githubusercontent.com/Luminara-Hub/namada-ecosystem/main/user-and-dev-tools/mainnet/rpc.json',
     indexer:
       'https://raw.githubusercontent.com/Luminara-Hub/namada-ecosystem/main/user-and-dev-tools/mainnet/namada-indexers.json',
+    maspIndexer:
+      'https://raw.githubusercontent.com/Luminara-Hub/namada-ecosystem/main/user-and-dev-tools/mainnet/masp-indexers.json',
+    interface:
+      'https://raw.githubusercontent.com/Luminara-Hub/namada-ecosystem/main/user-and-dev-tools/mainnet/interfaces.json',
   },
   testnet: {
     rpc: 'https://raw.githubusercontent.com/Luminara-Hub/namada-ecosystem/main/user-and-dev-tools/testnet/housefire/rpc.json',
     indexer:
       'https://raw.githubusercontent.com/Luminara-Hub/namada-ecosystem/main/user-and-dev-tools/testnet/housefire/namada-indexers.json',
+    maspIndexer:
+      'https://raw.githubusercontent.com/Luminara-Hub/namada-ecosystem/main/user-and-dev-tools/testnet/housefire/masp-indexers.json',
+    interface:
+      'https://raw.githubusercontent.com/Luminara-Hub/namada-ecosystem/main/user-and-dev-tools/testnet/housefire/interfaces.json',
   },
 };
 
@@ -84,18 +102,68 @@ const fetchIndexerEndpoints = async (url: string): Promise<NamadaNode[]> => {
   }
 };
 
+const fetchMaspIndexerEndpoints = async (url: string): Promise<NamadaNode[]> => {
+  try {
+    const response = await fetch(url);
+
+    if (!response.ok) {
+      logError(`Failed to fetch MASP indexer endpoints from ${url}: ${response.statusText}`);
+      return [];
+    }
+
+    const data = (await response.json()) as NamadaMASPEntry[];
+
+    return data
+      .filter((entry) => entry['Indexer API URL'] && entry['Team or Contributor Name'])
+      .map((entry) => ({
+        type: 'masp-indexer' as ChainNodeType,
+        url: entry['Indexer API URL'],
+        provider: entry['Team or Contributor Name'],
+      }));
+  } catch (error) {
+    logError(`Error fetching MASP indexer endpoints from ${url}:`, error);
+    return [];
+  }
+};
+
+const fetchInterfaceEndpoints = async (url: string): Promise<NamadaNode[]> => {
+  try {
+    const response = await fetch(url);
+
+    if (!response.ok) {
+      logError(`Failed to fetch interface endpoints from ${url}: ${response.statusText}`);
+      return [];
+    }
+
+    const data = (await response.json()) as NamadaInterfaceEntry[];
+
+    return data
+      .filter((entry) => entry['Interface URL'] && entry['Team or Contributor Name'] && entry['Available']?.toLowerCase() === 'yes')
+      .map((entry) => ({
+        type: 'interface' as ChainNodeType,
+        url: entry['Interface URL'],
+        provider: entry['Team or Contributor Name'],
+      }));
+  } catch (error) {
+    logError(`Error fetching interface endpoints from ${url}:`, error);
+    return [];
+  }
+};
+
 export const fetchNamadaInfrastructure = async (chainName: string): Promise<NamadaNode[]> => {
   const isTestnet = chainName.toLowerCase().includes('housefire') || chainName.toLowerCase().includes('testnet');
 
   const network = isTestnet ? 'testnet' : 'mainnet';
   const registries = NAMADA_REGISTRIES[network];
 
-  const [rpcNodes, indexerNodes] = await Promise.all([
+  const [rpcNodes, indexerNodes, maspIndexerNodes, interfaceNodes] = await Promise.all([
     fetchRPCEndpoints(registries.rpc),
     fetchIndexerEndpoints(registries.indexer),
+    fetchMaspIndexerEndpoints(registries.maspIndexer),
+    fetchInterfaceEndpoints(registries.interface),
   ]);
 
-  return [...rpcNodes, ...indexerNodes];
+  return [...rpcNodes, ...indexerNodes, ...maspIndexerNodes, ...interfaceNodes];
 };
 
 export default fetchNamadaInfrastructure;

--- a/src/app/[locale]/validators/[id]/(validator-profile)/public_goods/infrastructure/validator-nodes/validator-nodes.tsx
+++ b/src/app/[locale]/validators/[id]/(validator-profile)/public_goods/infrastructure/validator-nodes/validator-nodes.tsx
@@ -45,6 +45,8 @@ const ValidatorNodes: FC<OwnProps> = async ({
     ws: 'websocket nodes',
     indexer: 'indexer nodes',
     lcd: 'lcd nodes',
+    'masp-indexer': 'masp indexer nodes',
+    interface: 'interface nodes',
   };
 
   const nodesList = Object.entries(groupedByType)
@@ -54,8 +56,8 @@ const ValidatorNodes: FC<OwnProps> = async ({
       nodes: typeNodes as InfrastructureNode[],
     }))
     .sort((a, b) => {
-      const isALast = a.type === 'grpc' || a.type === 'ws';
-      const isBLast = b.type === 'grpc' || b.type === 'ws';
+      const isALast = a.type === 'grpc' || a.type === 'ws' || a.type === 'interface';
+      const isBLast = b.type === 'grpc' || b.type === 'ws' || b.type === 'interface';
 
       if (isALast && !isBLast) return 1;
       if (!isALast && isBLast) return -1;


### PR DESCRIPTION
**What:** Add gRPC/WebSocket health checking, MASP indexer and staking interface support to the infrastructure validators page.
**Why:** Closes #481
**How:**
- Added `checkGrpcHealth()` using TCP connection test via `net.Socket` (default port 9090)
- Added `checkWsHealth()` using HTTP upgrade handshake with WebSocket headers
- Added `checkNamadaIndexerHealth()` checking `/api/v1/chain/parameters` endpoint
- Removed skip logic for gRPC and WS nodes — they are now actively health-checked
- Added `masp-indexer` and `interface` to `ChainNodeType` union
- Extended Namada infrastructure fetching to pull MASP indexers (`masp-indexers.json`) and staking interfaces (`interfaces.json`) from Luminara-Hub registry
- Staking interfaces filtered by `Available === 'yes'`
- Both mainnet and testnet registries supported
- Added UI node type mappings in `validator-nodes.tsx`
- Added localization strings in all 3 locale files (en, pt, ru)
**Testing:** TypeScript type-check passes (`npx tsc --noEmit`), all changes reviewed