### PR TITLE
Pass explicit empty filters to the passport tx probe

### DIFF
--- a/src/app/[locale]/validators/[id]/[operatorAddress]/validator_passport/authz/node-details/node-details.tsx
+++ b/src/app/[locale]/validators/[id]/[operatorAddress]/validator_passport/authz/node-details/node-details.tsx
@@ -12,6 +12,7 @@ import authzService, { AuthzTabSlug } from '@/services/authz-service';
 import priceService from '@/services/price-service';
 import TxService from '@/services/tx-service';
 import voteService from '@/services/vote-service';
+import { EMPTY_TX_FILTERS } from '@/utils/tx-filters';
 
 interface OwnProps {
   locale: string;
@@ -47,7 +48,7 @@ const NodeDetails: FC<OwnProps> = async ({ authzTab, locale, validatorId, operat
     priceService.getLatestPriceByChainName(node.chain.name),
     voteService.getNodeVotingStatus(node.id, node.chainId),
     isTxLive && txAddresses.length > 0
-      ? TxService.getTxsByAddressBatch(node.chain.name, txAddresses)
+      ? TxService.getTxsByAddressBatch(node.chain.name, txAddresses, EMPTY_TX_FILTERS)
       : Promise.resolve(null),
   ]);
   // Chains without indexed votes/txs keep the legacy jailed-proxy instead of a definitive negative.


### PR DESCRIPTION
The Sends TXs indicator and the tx filters feature merged from separate branches: the filters work made the filters argument of getTxsByAddressBatch required, while the passport probe still called it without one, so the combined dev branch stopped compiling. Pass EMPTY_TX_FILTERS the same way the tx summary page does — the probe wants the unfiltered head batch either way.